### PR TITLE
Add file tab shortcuts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,7 +43,11 @@ const controller = Controller({
     settings,
     shortcuts: shortcuts({
       'cmd+s': 'app.saveClicked',
-      'ctrl+s': 'app.saveClicked'
+      'ctrl+s': 'app.saveClicked',
+      'ctrl+]': 'files.nextFileTabActivated',
+      'ctrl+[': 'files.previousFileTabActivated',
+      'cmd+[': 'files.previousFileTabActivated',
+      'cmd+]': 'files.nextFileTabActivated'
     }),
     useragent: UseragentModule()
   },

--- a/src/modules/files/factories/activateTab.js
+++ b/src/modules/files/factories/activateTab.js
@@ -1,0 +1,11 @@
+import updateFileIndexFactory from './updateFileIndex'
+import fileClicked from '../signals/fileClicked'
+
+export default (direction) => {
+  return [
+    updateFileIndexFactory(direction), {
+      updated: fileClicked,
+      noop: []
+    }
+  ]
+}

--- a/src/modules/files/factories/updateFileIndex.js
+++ b/src/modules/files/factories/updateFileIndex.js
@@ -1,0 +1,12 @@
+export default function updateFileIndexFactory(direction) {
+  return ({state, props, path}) => {
+    const index = state.get('app.currentBin.selectedFileIndex')
+    const newIndex = eval(`${index} ${direction} 1`)
+
+    if (state.get('app.currentBin.files')[newIndex]) {
+      return path.updated({index: newIndex})
+    } else {
+      return path.noop()
+    }
+  }
+}

--- a/src/modules/files/index.js
+++ b/src/modules/files/index.js
@@ -6,10 +6,13 @@ import newFileClicked from './signals/newFileClicked'
 import newFileNameChanged from './signals/newFileNameChanged'
 import newFileNameSubmitted from './signals/newFileNameSubmitted'
 import preventWhenLiveParticipant from 'modules/app/factories/preventWhenLiveParticipant'
+import activateTab from 'modules/files/factories/activateTab'
 
 export default {
   signals: {
     fileClicked: preventWhenLiveParticipant(fileClicked),
+    nextFileTabActivated: preventWhenLiveParticipant(activateTab('+')),
+    previousFileTabActivated: preventWhenLiveParticipant(activateTab('-')),
     removeFileClicked: preventWhenLiveParticipant(removeFileClicked),
     isEntryToggled: preventWhenLiveParticipant(isEntryToggled),
     newFileAborted: preventWhenLiveParticipant(newFileAborted),

--- a/src/modules/shortcuts/index.js
+++ b/src/modules/shortcuts/index.js
@@ -1,28 +1,17 @@
+const MODIFIER = {
+  ctrl: 'ctrlKey',
+  cmd: 'metaKey',
+  alt: 'altKey'
+}
+
 export default function (shortcuts) {
   return function (module) {
     module.controller.on('initialized', function () {
       Object.keys(shortcuts).forEach(function (shortcut) {
-        const keyCodes = shortcut.split('+')
-        const keyCode = keyCodes.pop().toUpperCase().charCodeAt(0)
-        const specialKey = keyCodes[0]
+        const [command,key] = shortcut.split('+')
 
         window.addEventListener('keydown', function (event) {
-          if (specialKey === 'ctrl' && !event.crlKey) {
-            return
-          }
-          if (specialKey === 'cmd' && !event.metaKey) {
-            return
-          }
-
-          if (specialKey === 'alt' && !event.altKey) {
-            return
-          }
-
-          if (specialKey === 'shift' && !event.shiftKey) {
-            return
-          }
-
-          if (event.keyCode === keyCode) {
+          if (event.key === key && event[MODIFIER[command]]) {
             event.preventDefault()
             event.stopPropagation()
             module.controller.getSignal(shortcuts[shortcut])()


### PR DESCRIPTION
#### Summary

- Adds keyboard shortcuts for navigating between open files with `cmd+[` and `cmd+]` (and `ctrl`). 
- Also fixed a bug/refactored in `shortcuts/index.js`. Issue was that `event.keyCode` and the unicode value returned from `String.prototype.charCodeAt(0)` are not *always* the same. Often they are, like for chars like `s`. but not for the `'['` char. Was easier to compare using `event.key` and then check if a modifier key is registered & pressed instead.