### PR TITLE
Use `inline-source-map` in development for better debugging

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,7 +128,7 @@ const common = [
  */
 module.exports = {
   target: 'web',
-  devtool: isProduction ? 'source-map' : 'eval-source-map',
+  devtool: isProduction ? 'source-map' : 'inline-source-map',
   performance: {
     hints: isProduction ? 'warning' : false
   },


### PR DESCRIPTION
I've just ran the project for the first time and had some errors, but it's was very difficult to understand where they were originated.

Before:
<img width="762" alt="before" src="https://cloud.githubusercontent.com/assets/480469/26038310/49458a48-390e-11e7-9842-8462238a2ecd.png">

A much better sourcemap scheme for development is `inline-source-map`.  
After:
<img width="766" alt="after" src="https://cloud.githubusercontent.com/assets/480469/26038317/6bf5a668-390e-11e7-8b5c-7214d8fa80c9.png">
