### PR TITLE
ES2016 → ES2015 in the UI to match the code

### DIFF
--- a/src/modules/configure/index.js
+++ b/src/modules/configure/index.js
@@ -15,7 +15,7 @@ export default {
     showQuickstart: false,
     quickstarts: [{
       title: 'ES2015',
-      description: 'Creates an entrypoint with ES2016 transpiling, ready for you to add any NPM packages',
+      description: 'Creates an entrypoint with ES2015 transpiling, ready for you to add any NPM packages',
       template: 'es2015'
     }, {
       title: 'Typescript',


### PR DESCRIPTION
It actually uses babel-preset-es2015, so ES2015 is correct.